### PR TITLE
Fix namespace clash & use events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,5 @@ dlldata.c
 .idea/
 *.sln.iml
 
-# FlatBuffers
-FlatBuffer/
+# Generated flatbuffers
+RLBot/Flat/

--- a/Tests/Atba/Atba.cs
+++ b/Tests/Atba/Atba.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 using MyBot.Math;
-using RLBot.flat;
+using RLBot.Flat;
 
 Atba bot = new();
 bot.Run();
@@ -18,20 +18,20 @@ class Atba : Bot
         Logger.LogInformation($"There are {numBoostPads} boost pads on the field.");
     }
 
-    public override ControllerStateT GetOutput(GamePacketT Packet)
+    public override ControllerStateT GetOutput(GamePacketT packet)
     {
         ControllerStateT controller = new();
 
         if (
-            Packet.GameInfo.GameStatus != GameStatus.Active
-                && Packet.GameInfo.GameStatus != GameStatus.Kickoff
-            || Packet.Balls.Count == 0
+            packet.GameInfo.GameStatus != GameStatus.Active
+                && packet.GameInfo.GameStatus != GameStatus.Kickoff
+            || packet.Balls.Count == 0
         )
             return controller;
 
-        Vec2 ballLocation = new(Packet.Balls[0].Physics.Location);
+        Vec2 ballLocation = new(packet.Balls[0].Physics.Location);
 
-        PlayerInfoT myCar = Packet.Players[Index];
+        PlayerInfoT myCar = packet.Players[Index];
         Vec2 carLocation = new(myCar.Physics.Location);
         Vec2 carDirection = myCar.GetCarFacingVector();
         Vec2 carToBall = ballLocation - carLocation;

--- a/Tests/Atba/Math.cs
+++ b/Tests/Atba/Math.cs
@@ -1,4 +1,4 @@
-using RLBot.flat;
+using RLBot.Flat;
 
 namespace MyBot.Math;
 

--- a/generate-flatbuffers.bat
+++ b/generate-flatbuffers.bat
@@ -4,11 +4,11 @@ cd /D "%~dp0"
 
 echo Generating flatbuffers header file...
 
-.\flatbuffers-schema\flatc.exe --csharp --gen-all --gen-object-api --gen-onefile -o .\FlatBuffer .\flatbuffers-schema\rlbot.fbs
+.\flatbuffers-schema\flatc.exe --csharp --gen-all --gen-object-api --gen-onefile -o .\RLBot\Flat .\flatbuffers-schema\rlbot.fbs
 
-IF EXIST .\FlatBuffer\rlbot.cs del .\FlatBuffer\rlbot.cs
+IF EXIST .\RLBot\Flat\Flat.cs del .\RLBot\Flat\Flat.cs
 
-REM the file produced is called rlbot_generated.cs, rename it to rlbot.cs after removing the old one
-ren .\FlatBuffer\rlbot_generated.cs rlbot.cs
+REM the file produced is called rlbot_generated.cs, rename it to Flat.cs after removing the old one
+ren .\RLBot\Flat\rlbot_generated.cs Flat.cs
 
 echo Done.

--- a/generate-flatbuffers.sh
+++ b/generate-flatbuffers.sh
@@ -4,10 +4,10 @@ cd "$(dirname "$0")"
 
 echo Generating flatbuffers header file...
 
-./flatbuffers-schema/flatc --gen-all --csharp --gen-object-api --gen-onefile -o ./FlatBuffer ./flatbuffers-schema/rlbot.fbs
+./flatbuffers-schema/flatc --gen-all --csharp --gen-object-api --gen-onefile -o ./RLBot/Flat ./flatbuffers-schema/rlbot.fbs
 
 # the file produced is called rlbot_generated.cs, rename it to rlbot.cs after removing the old one
-rm -f ./FlatBuffer/rlbot.cs
-mv ./FlatBuffer/rlbot_generated.cs ./FlatBuffer/rlbot.cs
+rm -f ./RLBot/Flat/Flat.cs
+mv ./RLBot/Flat/rlbot_generated.cs ./RLBot/Flat/Flat.cs
 
 echo Done.

--- a/rlbot/Manager/Bot.cs
+++ b/rlbot/Manager/Bot.cs
@@ -1,20 +1,20 @@
 using Microsoft.Extensions.Logging;
 using RLBot;
-using RLBot.flat;
+using RLBot.Flat;
 using RLBot.Util;
 
 public abstract class Bot
 {
     public Logging Logger = new("rlbot", LogLevel.Information);
 
-    public int Team = -1;
-    public int Index = -1;
-    public string Name = "";
-    public int SpawnId = -1;
+    public int Team { get; private set; } = -1;
+    public int Index { get; private set; } = -1;
+    public string Name { get; private set; } = "";
+    public int SpawnId { get; private set; } = -1;
 
-    public MatchSettingsT MatchSettings = new();
-    public FieldInfoT FieldInfo = new();
-    public BallPredictionT BallPrediction = new();
+    public MatchSettingsT MatchSettings { get; private set; } = new();
+    public FieldInfoT FieldInfo { get; private set; } = new();
+    public BallPredictionT BallPrediction { get; private set; } = new();
 
     private bool _initializedBot = false;
     private bool _hasMatchSettings = false;
@@ -42,15 +42,15 @@ public abstract class Bot
                 "Environment variable RLBOT_AGENT_ID is not set and no default agent id is passed to the constructor of the bot."
             );
         }
-
+        
         Logger = new Logging("Bot", LogLevel.Information);
         _gameInterface = new Interface(agentId, logger: Logger);
-        _gameInterface.MatchSettingsHandlers.Add(HandleMatchSettings);
-        _gameInterface.FieldInfoHandlers.Add(HandleFieldInfo);
-        _gameInterface.MatchCommunicationHandlers.Add(HandleMatchCommunication);
-        _gameInterface.BallPredictionHandlers.Add(HandleBallPrediction);
-        _gameInterface.ControllableTeamInfoHandlers.Add(HandleControllableTeamInfo);
-        _gameInterface.GamePacketHandlers.Add(HandleGamePacket);
+        _gameInterface.OnMatchSettingsCallback += HandleMatchSettings;
+        _gameInterface.OnFieldInfoCallback += HandleFieldInfo;
+        _gameInterface.OnMatchCommunicationCallback += HandleMatchCommunication;
+        _gameInterface.OnBallPredictionCallback += HandleBallPrediction;
+        _gameInterface.OnControllableTeamInfoCallback += HandleControllableTeamInfo;
+        _gameInterface.OnGamePacketCallback += HandleGamePacket;
     }
 
     private void TryInitialize()
@@ -235,5 +235,5 @@ public abstract class Bot
 
     public virtual void Retire() { }
 
-    public abstract ControllerStateT GetOutput(GamePacketT GamePacket);
+    public abstract ControllerStateT GetOutput(GamePacketT packet);
 }

--- a/rlbot/Util/SocketSpecStreamWriter.cs
+++ b/rlbot/Util/SocketSpecStreamWriter.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 namespace RLBot.Util;
 
 /**
- * Communicates with bots and scripts over TCP according to the spec
+ * Communicates with bots and scripts over TCP according to the specification
  * defined at https://wiki.rlbot.org/framework/sockets-specification/
  */
 internal class SocketSpecStreamWriter(Stream stream)

--- a/rlbot/rlbot.csproj
+++ b/rlbot/rlbot.csproj
@@ -17,8 +17,9 @@
   <ItemGroup>
     <PackageReference Include="Google.FlatBuffers" Version="24.3.25" />
   </ItemGroup>
+
   <ItemGroup>
-    <Folder Include="FlatBuffer\" />
+    <Folder Include="Flat\" />
   </ItemGroup>
 
   <Target Name="GenerateFlatBuffersWindows" BeforeTargets="PreBuildEvent" Condition=" '$(OS)' == 'Windows_NT' ">
@@ -28,8 +29,4 @@
   <Target Name="GenerateFlatBuffersLinux" BeforeTargets="PreBuildEvent" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
     <Exec Command="../generate-flatbuffers.sh" />
   </Target>
-
-  <ItemGroup>
-    <Compile Include="..\FlatBuffer\rlbot.cs" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Created a compilation issue in #1. Whoops. Fixed it by changing the flatbuffer schema to use a capitalized namespace. This created a name conflict with the bot kind named "RLBot" so it was renamed to "CustomBot".

The PR also replaces the list of actions in `Interface` with event callbacks, and introduces some properties with private setters.