### PR TITLE
Depend upon main branch of flatbuffers schema

### DIFF
--- a/generate-flatbuffers.bat
+++ b/generate-flatbuffers.bat
@@ -11,4 +11,8 @@ IF EXIST .\RLBot\Flat\Flat.cs del .\RLBot\Flat\Flat.cs
 REM the file produced is called rlbot_generated.cs, rename it to Flat.cs after removing the old one
 ren .\RLBot\Flat\rlbot_generated.cs Flat.cs
 
+REM CMD doesn't have native text replacement tools, use PowerShell
+REM Replaces 'rlbot.flat' with 'RLBot.Flat'
+powershell -Command "(Get-Content .\RLBot\Flat\Flat.cs) -replace 'rlbot\.flat', 'RLBot.Flat' | Set-Content .\RLBot\Flat\Flat.cs"
+
 echo Done.

--- a/generate-flatbuffers.sh
+++ b/generate-flatbuffers.sh
@@ -9,5 +9,6 @@ echo Generating flatbuffers header file...
 # the file produced is called rlbot_generated.cs, rename it to rlbot.cs after removing the old one
 rm -f ./RLBot/Flat/Flat.cs
 mv ./RLBot/Flat/rlbot_generated.cs ./RLBot/Flat/Flat.cs
+sed -i 's/rlbot\.flat/RLBot.Flat/g' ./RLBot/Flat/Flat.cs
 
 echo Done.


### PR DESCRIPTION
Updates the build scripts to also replace instances of `rlbot.flat` with `RLBot.Flat`.

This automates the process we were doing manually before