### PR TITLE
Make state setting easier through builder pattern

### DIFF
--- a/RLBot/GameState/DesiredBallStateBuilder.cs
+++ b/RLBot/GameState/DesiredBallStateBuilder.cs
@@ -1,0 +1,219 @@
+using RLBot.Flat;
+using Vector3 = System.Numerics.Vector3;
+
+namespace RLBot.GameState;
+
+public class DesiredBallStateBuilder
+{
+    private readonly DesiredBallStateT _ballState;
+
+    public DesiredBallStateBuilder(DesiredBallStateT ballState)
+    {
+        _ballState = ballState;
+        ballState.Physics ??= new DesiredPhysicsT();
+    }
+    
+    /// <summary>
+    /// Set the desired location of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder Location(Vector3 location)
+    {
+        _ballState.Physics.Location = new Vector3PartialT()
+        {
+            X = new FloatT { Val = location.X },
+            Y = new FloatT { Val = location.Y },
+            Z = new FloatT { Val = location.Z }
+        };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired location of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder Location(Flat.Vector3 location)
+    {
+        _ballState.Physics.Location = new Vector3PartialT()
+        {
+            X = new FloatT { Val = location.X },
+            Y = new FloatT { Val = location.Y },
+            Z = new FloatT { Val = location.Z }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the X value of the desired location of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder LocationX(float value)
+    {
+        _ballState.Physics.Location ??= new Vector3PartialT();
+        _ballState.Physics.Location.X = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Y value of the desired location of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder LocationY(float value)
+    {
+        _ballState.Physics.Location ??= new Vector3PartialT();
+        _ballState.Physics.Location.Y = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Z value of the desired location of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder LocationZ(float value)
+    {
+        _ballState.Physics.Location ??= new Vector3PartialT();
+        _ballState.Physics.Location.Z = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder Velocity(Vector3 velocity)
+    {
+        _ballState.Physics.Velocity = new Vector3PartialT()
+        {
+            X = new FloatT { Val = velocity.X },
+            Y = new FloatT { Val = velocity.Y },
+            Z = new FloatT { Val = velocity.Z }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the X value of the desired velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder VelocityX(float value)
+    {
+        _ballState.Physics.Velocity ??= new Vector3PartialT();
+        _ballState.Physics.Velocity.X = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Y value of the desired velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder VelocityY(float value)
+    {
+        _ballState.Physics.Velocity ??= new Vector3PartialT();
+        _ballState.Physics.Velocity.Y = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Z value of the desired velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder VelocityZ(float value)
+    {
+        _ballState.Physics.Velocity ??= new Vector3PartialT();
+        _ballState.Physics.Velocity.Z = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired angular velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder AngularVelocity(Vector3 angVel)
+    {
+        _ballState.Physics.AngularVelocity = new Vector3PartialT()
+        {
+            X = new FloatT { Val = angVel.X },
+            Y = new FloatT { Val = angVel.Y },
+            Z = new FloatT { Val = angVel.Z }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the X value of the desired angular velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder AngularVelocityX(float value)
+    {
+        _ballState.Physics.AngularVelocity ??= new Vector3PartialT();
+        _ballState.Physics.AngularVelocity.X = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Y value of the desired angular velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder AngularVelocityY(float value)
+    {
+        _ballState.Physics.AngularVelocity ??= new Vector3PartialT();
+        _ballState.Physics.AngularVelocity.Y = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Z value of the desired angular velocity of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder AngularVelocityZ(float value)
+    {
+        _ballState.Physics.AngularVelocity ??= new Vector3PartialT();
+        _ballState.Physics.AngularVelocity.Z = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired rotation of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder Rotation(Vector3 rotation)
+    {
+        _ballState.Physics.Rotation = new RotatorPartialT()
+        {
+            Pitch = new FloatT { Val = rotation.X },
+            Yaw = new FloatT { Val = rotation.Y },
+            Roll = new FloatT { Val = rotation.Z }
+        };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired rotation of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder Rotation(RotatorT rotation)
+    {
+        _ballState.Physics.Rotation = new RotatorPartialT()
+        {
+            Pitch = new FloatT { Val = rotation.Pitch },
+            Yaw = new FloatT { Val = rotation.Yaw },
+            Roll = new FloatT { Val = rotation.Roll }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the pitch value of the desired rotation of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder RotationPitch(float value)
+    {
+        _ballState.Physics.Rotation ??= new RotatorPartialT();
+        _ballState.Physics.Rotation.Pitch = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the yaw value of the desired rotation of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder RotationYaw(float value)
+    {
+        _ballState.Physics.Rotation ??= new RotatorPartialT();
+        _ballState.Physics.Rotation.Yaw = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the roll value of the desired rotation of the ball.
+    /// </summary>
+    public DesiredBallStateBuilder RotationRoll(float value)
+    {
+        _ballState.Physics.Rotation ??= new RotatorPartialT();
+        _ballState.Physics.Rotation.Roll = new FloatT { Val = value };
+        return this;
+    }
+}

--- a/RLBot/GameState/DesiredCarStateBuilder.cs
+++ b/RLBot/GameState/DesiredCarStateBuilder.cs
@@ -1,0 +1,233 @@
+using RLBot.Flat;
+using Vector3 = System.Numerics.Vector3;
+
+namespace RLBot.GameState;
+
+public class DesiredCarStateBuilder
+{
+    private readonly DesiredCarStateT _carState;
+
+    public DesiredCarStateBuilder(DesiredCarStateT carState)
+    {
+        _carState = carState;
+        carState.Physics ??= new DesiredPhysicsT();
+    }
+
+    public DesiredCarStateT Build()
+    {
+        return _carState;
+    }
+
+    /// <summary>
+    /// Set the desired boost amount. 
+    /// </summary>
+    public DesiredCarStateBuilder Boost(float value)
+    {
+        _carState.BoostAmount = new FloatT() { Val = value };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the desired location of the car.
+    /// </summary>
+    public DesiredCarStateBuilder Location(Vector3 location)
+    {
+        _carState.Physics.Location = new Vector3PartialT()
+        {
+            X = new FloatT { Val = location.X },
+            Y = new FloatT { Val = location.Y },
+            Z = new FloatT { Val = location.Z }
+        };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired location of the car.
+    /// </summary>
+    public DesiredCarStateBuilder Location(Flat.Vector3 location)
+    {
+        _carState.Physics.Location = new Vector3PartialT()
+        {
+            X = new FloatT { Val = location.X },
+            Y = new FloatT { Val = location.Y },
+            Z = new FloatT { Val = location.Z }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the X value of the desired location of the car.
+    /// </summary>
+    public DesiredCarStateBuilder LocationX(float value)
+    {
+        _carState.Physics.Location ??= new Vector3PartialT();
+        _carState.Physics.Location.X = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Y value of the desired location of the car.
+    /// </summary>
+    public DesiredCarStateBuilder LocationY(float value)
+    {
+        _carState.Physics.Location ??= new Vector3PartialT();
+        _carState.Physics.Location.Y = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Z value of the desired location of the car.
+    /// </summary>
+    public DesiredCarStateBuilder LocationZ(float value)
+    {
+        _carState.Physics.Location ??= new Vector3PartialT();
+        _carState.Physics.Location.Z = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder Velocity(Vector3 velocity)
+    {
+        _carState.Physics.Velocity = new Vector3PartialT()
+        {
+            X = new FloatT { Val = velocity.X },
+            Y = new FloatT { Val = velocity.Y },
+            Z = new FloatT { Val = velocity.Z }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the X value of the desired velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder VelocityX(float value)
+    {
+        _carState.Physics.Velocity ??= new Vector3PartialT();
+        _carState.Physics.Velocity.X = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Y value of the desired velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder VelocityY(float value)
+    {
+        _carState.Physics.Velocity ??= new Vector3PartialT();
+        _carState.Physics.Velocity.Y = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Z value of the desired velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder VelocityZ(float value)
+    {
+        _carState.Physics.Velocity ??= new Vector3PartialT();
+        _carState.Physics.Velocity.Z = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired angular velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder AngularVelocity(Vector3 angVel)
+    {
+        _carState.Physics.AngularVelocity = new Vector3PartialT()
+        {
+            X = new FloatT { Val = angVel.X },
+            Y = new FloatT { Val = angVel.Y },
+            Z = new FloatT { Val = angVel.Z }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the X value of the desired angular velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder AngularVelocityX(float value)
+    {
+        _carState.Physics.AngularVelocity ??= new Vector3PartialT();
+        _carState.Physics.AngularVelocity.X = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Y value of the desired angular velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder AngularVelocityY(float value)
+    {
+        _carState.Physics.AngularVelocity ??= new Vector3PartialT();
+        _carState.Physics.AngularVelocity.Y = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the Z value of the desired angular velocity of the car.
+    /// </summary>
+    public DesiredCarStateBuilder AngularVelocityZ(float value)
+    {
+        _carState.Physics.AngularVelocity ??= new Vector3PartialT();
+        _carState.Physics.AngularVelocity.Z = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired rotation of the car.
+    /// </summary>
+    public DesiredCarStateBuilder Rotation(Vector3 rotation)
+    {
+        _carState.Physics.Rotation = new RotatorPartialT()
+        {
+            Pitch = new FloatT { Val = rotation.X },
+            Yaw = new FloatT { Val = rotation.Y },
+            Roll = new FloatT { Val = rotation.Z }
+        };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the desired rotation of the car.
+    /// </summary>
+    public DesiredCarStateBuilder Rotation(RotatorT rotation)
+    {
+        _carState.Physics.Rotation = new RotatorPartialT()
+        {
+            Pitch = new FloatT { Val = rotation.Pitch },
+            Yaw = new FloatT { Val = rotation.Yaw },
+            Roll = new FloatT { Val = rotation.Roll }
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the pitch value of the desired rotation of the car.
+    /// </summary>
+    public DesiredCarStateBuilder RotationPitch(float value)
+    {
+        _carState.Physics.Rotation ??= new RotatorPartialT();
+        _carState.Physics.Rotation.Pitch = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the yaw value of the desired rotation of the car.
+    /// </summary>
+    public DesiredCarStateBuilder RotationYaw(float value)
+    {
+        _carState.Physics.Rotation ??= new RotatorPartialT();
+        _carState.Physics.Rotation.Yaw = new FloatT { Val = value };
+        return this;
+    }
+    
+    /// <summary>
+    /// Set the roll value of the desired rotation of the car.
+    /// </summary>
+    public DesiredCarStateBuilder RotationRoll(float value)
+    {
+        _carState.Physics.Rotation ??= new RotatorPartialT();
+        _carState.Physics.Rotation.Roll = new FloatT { Val = value };
+        return this;
+    }
+}

--- a/RLBot/GameState/DesiredGameStateBuilder.cs
+++ b/RLBot/GameState/DesiredGameStateBuilder.cs
@@ -1,0 +1,67 @@
+using RLBot.Flat;
+
+namespace RLBot.GameState;
+
+public class DesiredGameStateBuilder(Interface @interface)
+{
+    private readonly DesiredGameStateT _state = new()
+    {
+        BallStates = new(),
+        CarStates = new(),
+        ConsoleCommands = new(),
+    };
+
+    /// <summary>
+    /// Modify the desired match info.
+    /// </summary>
+    public DesiredGameStateBuilder MatchInfo(Func<DesiredMatchInfoBuilder, DesiredMatchInfoBuilder> build)
+    {
+        var builder = new DesiredMatchInfoBuilder(_state.MatchInfo ?? new DesiredMatchInfoT());
+        build(builder);
+        return this;
+    }
+
+    /// <summary>
+    /// Modify the desired car state at the given index.
+    /// </summary>
+    public DesiredGameStateBuilder Car(int index, Func<DesiredCarStateBuilder, DesiredCarStateBuilder> build)
+    {
+        while (_state.CarStates.Count <= index)
+        {
+            _state.CarStates.Add(new());
+        }
+
+        var builder = new DesiredCarStateBuilder(_state.CarStates[index]);
+        build(builder);
+        return this;
+    }
+    
+    /// <summary>
+    /// Modify the desired ball state at the given index.
+    /// </summary>
+    public DesiredGameStateBuilder Ball(int index, Func<DesiredBallStateBuilder, DesiredBallStateBuilder> build)
+    {
+        while (_state.BallStates.Count <= index)
+        {
+            _state.BallStates.Add(new());
+        }
+
+        var builder = new DesiredBallStateBuilder(_state.BallStates[index]);
+        build(builder);
+        return this;
+    }
+
+    /// <summary>
+    /// Add a console command.
+    /// </summary>
+    public DesiredGameStateBuilder Command(string cmd)
+    {
+        _state.ConsoleCommands.Add(new() { Command = cmd });
+        return this;
+    }
+
+    public void BuildAndSend()
+    {
+        @interface.SendGameState(_state);
+    }
+}

--- a/RLBot/GameState/DesiredMatchInfoBuilder.cs
+++ b/RLBot/GameState/DesiredMatchInfoBuilder.cs
@@ -1,0 +1,29 @@
+using RLBot.Flat;
+
+namespace RLBot.GameState;
+
+public class DesiredMatchInfoBuilder(DesiredMatchInfoT matchInfo)
+{
+    public DesiredMatchInfoT Build()
+    {
+        return matchInfo;
+    }
+
+    /// <summary>
+    /// Set the world gravity z.  
+    /// </summary>
+    public DesiredMatchInfoBuilder GravityZ(float value)
+    {
+        matchInfo.WorldGravityZ = new FloatT { Val = value };
+        return this;
+    }
+
+    /// <summary>
+    /// Set the game speed modifier.
+    /// </summary>
+    public DesiredMatchInfoBuilder GameSpeed(float value)
+    {
+        matchInfo.GameSpeed = new FloatT { Val = value };
+        return this;
+    }
+}

--- a/RLBot/Manager/Bot.cs
+++ b/RLBot/Manager/Bot.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using RLBot.Flat;
+using RLBot.GameState;
 using RLBot.Util;
 
 namespace RLBot.Manager;
@@ -251,6 +252,14 @@ public abstract class Bot
     {
         var gameState = GameStateExt.FillDesiredGameState(balls, cars, matchInfo, commands);
         _gameInterface.SendGameState(gameState);
+    }
+
+    /// <summary>
+    /// Modify the current game state using a builder pattern.
+    /// </summary>
+    public DesiredGameStateBuilder GameStateBuilder()
+    {
+        return new DesiredGameStateBuilder(_gameInterface);
     }
 
     public virtual void Retire() { }

--- a/RLBot/Manager/Match.cs
+++ b/RLBot/Manager/Match.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using RLBot.Flat;
+using RLBot.GameState;
 using RLBot.Util;
 
 namespace RLBot.Manager;
@@ -136,6 +137,14 @@ public class Match
         }
     }
 
+    /// <summary>
+    /// Modify the current game state using a builder pattern.
+    /// </summary>
+    public DesiredGameStateBuilder GameStateBuilder()
+    {
+        return new DesiredGameStateBuilder(_gameInterface);
+    }
+    
     public void SetGameState(
         Dictionary<int, DesiredBallStateT>? balls = null,
         Dictionary<int, DesiredCarStateT>? cars = null,

--- a/RLBot/Manager/Script.cs
+++ b/RLBot/Manager/Script.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using RLBot.Flat;
+using RLBot.GameState;
 using RLBot.Util;
 
 namespace RLBot.Manager;
@@ -218,6 +219,14 @@ public abstract class Script
     public void SetLoadout(SetLoadoutT setLoadout) =>
         _gameInterface.SendSetLoadout(setLoadout);
 
+    /// <summary>
+    /// Modify the current game state using a builder pattern.
+    /// </summary>
+    public DesiredGameStateBuilder GameStateBuilder()
+    {
+        return new DesiredGameStateBuilder(_gameInterface);
+    }
+    
     public void SetGameState(
         Dictionary<int, DesiredBallStateT>? balls = null,
         Dictionary<int, DesiredCarStateT>? cars = null,

--- a/Tests/TestScript/TestScript.cs
+++ b/Tests/TestScript/TestScript.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using RLBot.Flat;
+using Vector3 = System.Numerics.Vector3;
 using RLBot.Manager;
 
 TestScript script = new TestScript();
@@ -10,7 +11,9 @@ class TestScript : Script
     private float _next = 10f;
 
     public TestScript()
-        : base("test/csharp_script") { }
+        : base("test/csharp_script")
+    {
+    }
 
     public override void Initialize()
     {
@@ -22,14 +25,14 @@ class TestScript : Script
         if (packet.MatchInfo.SecondsElapsed < _next || packet.Balls.Count == 0)
             return;
 
-        Dictionary<int, DesiredBallStateT> balls = new();
-        DesiredBallStateT ball = new DesiredBallStateT();
-        ball.Physics = new DesiredPhysicsT();
-        ball.Physics.Velocity = new Vector3PartialT();
-        ball.Physics.Velocity.Y = new FloatT();
-        ball.Physics.Velocity.Y.Val = packet.Balls[0].Physics.Velocity.Y + 1000f;
-        balls.Add(0, ball);
-        SetGameState(balls: balls);
+        // State setting
+        GameStateBuilder()
+            .Ball(0, c => c
+                .Location(Vector3.UnitZ * 93)
+                .VelocityZ(packet.Balls[0].Physics.Velocity.Z + 1000f)
+            )
+            .Car(1, c => c.Boost(100).RotationYaw(0))
+            .BuildAndSend();
 
         _next = packet.MatchInfo.SecondsElapsed + 10f;
     }


### PR DESCRIPTION
This PR adds a builder for desired game states making it much easier to do game state setting.

---

Example. Each of the three code blocks perform the same state setting.

Before (initializer pattern):
```cs
Dictionary<int, DesiredBallStateT> balls = new()
{
    {
        0, new DesiredBallStateT
        {
            Physics = new DesiredPhysicsT
            {
                Velocity = new Vector3PartialT
                {
                    Z = new FloatT() { Val = packet.Balls[0].Physics.Velocity.Z + 1000f }
                }
            }
        }
    }
};
Dictionary<int, DesiredCarStateT> cars = new()
{
    {
        1, new DesiredCarStateT
        {
            BoostAmount = new FloatT() { Val = 100 }
        }
    }
};
SetGameState(balls: balls, cars: cars);
```

Before (individual assignments):
```cs
Dictionary<int, DesiredBallStateT> balls = new();
DesiredBallStateT ball = new DesiredBallStateT();
ball.Physics = new DesiredPhysicsT();
ball.Physics.Velocity = new Vector3PartialT();
ball.Physics.Velocity.Z = new FloatT() { Val = packet.Balls[0].Physics.Velocity.Z + 1000f };
balls.Add(0, ball);
Dictionary<int, DesiredCarStateT> cars = new();
DesiredCarStateT car = new DesiredCarStateT();
car.BoostAmount = new FloatT() { Val = 100 };
cars.Add(1, car);
SetGameState(balls: balls, cars: cars);
```

Now (builder pattern):
```cs
GameStateBuilder()
    .Ball(0, ball => ball
        .Location(Vector3.UnitZ * 93)
        .VelocityZ(packet.Balls[0].Physics.Velocity.Z + 1000f)
    )
    .Car(0, car => car.Boost(100))
    .BuildAndSend();
```